### PR TITLE
[Repo Assist] ci: upgrade GitHub Actions versions and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "enhancement"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
@@ -26,7 +26,7 @@ jobs:
 
       - name: Auto-commit updated README
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "docs: auto-regenerate README function reference"
           file_pattern: README.md
@@ -34,7 +34,7 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run CI
         run: ./ci.ps1 -Target windows
@@ -43,7 +43,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run CI
         run: ./ci.ps1 -Target linux
@@ -52,7 +52,7 @@ jobs:
   arm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install cross-compilers
         run: sudo apt-get update && sudo apt-get install -y gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu qemu-user


### PR DESCRIPTION
- actions/checkout: v4 -> v6 (Node.js 24, persist-credentials improvement)
- stefanzweifel/git-auto-commit-action: v5 -> v7 (uses actions/checkout v6)
- Add .github/dependabot.yml for automatic weekly action version updates

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
