### PR TITLE
l_tls: add socket timeouts to prevent hangs on unresponsive peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,7 +758,7 @@ Generated from doc-comments. Run `.\gen-docs.ps1` to regenerate.
 | **Arena function declarations** | | |
 | `l_arena_init` | Allocate an arena of `size` bytes via mmap. On failure, base=NULL. | All |
 | `l_arena_alloc` | Bump-allocate n bytes (8-byte aligned). Returns NULL if arena is full. | All |
-| `l_arena_reset` | Reset used to 0. Memory is NOT freed — arena can be reused. | All |
+| `l_arena_reset` | Reset used to 0. Memory is NOT freed â€” arena can be reused. | All |
 | `l_arena_free` | Free the backing memory. Sets base=NULL. | All |
 | **Buffer function declarations** | | |
 | `l_buf_init` | Zero-initialize a buffer. | All |
@@ -766,7 +766,7 @@ Generated from doc-comments. Run `.\gen-docs.ps1` to regenerate.
 | `l_buf_printf` | Formatted append using l_vsnprintf. Returns bytes written or -1. | All |
 | `l_buf_clear` | Set len=0 (keep allocated memory). | All |
 | `l_buf_free` | Free backing memory and zero the struct. | All |
-| **L_Str — fat string (pointer + length) function declarations** | | |
+| **L_Str â€” fat string (pointer + length) function declarations** | | |
 | `l_str` | Wrap a C string (computes strlen). | All |
 | `l_str_from` | Wrap pointer+length. | All |
 | `l_str_null` | Return null string {NULL, 0}. | All |
@@ -1220,7 +1220,7 @@ Which `l_os.h` functions work on which platform. Generated from code annotations
 | ``l_buf_printf`` | ✅ | ✅ | ✅ |
 | ``l_buf_clear`` | ✅ | ✅ | ✅ |
 | ``l_buf_free`` | ✅ | ✅ | ✅ |
-| **L_Str — fat string (pointer + length) function declarations** | | | |
+| **L_Str â€” fat string (pointer + length) function declarations** | | | |
 | ``l_str`` | ✅ | ✅ | ✅ |
 | ``l_str_from`` | ✅ | ✅ | ✅ |
 | ``l_str_null`` | ✅ | ✅ | ✅ |
@@ -1342,15 +1342,15 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 |----------|--------|-----------|
 | **String functions** | | |
 | `l_wcslen` | ✅ | test_strings.c |
-| `l_strlen` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
-| `l_strcpy` | ✅ | test_strings.c, test.c |
+| `l_strlen` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
+| `l_strcpy` | ✅ | test.c, test_strings.c |
 | `l_strncpy` | ✅ | test_strings.c |
-| `l_strcat` | ✅ | test_strings.c, test.c |
+| `l_strcat` | ✅ | test.c, test_strings.c |
 | `l_strncat` | ✅ | test_strings.c |
 | `l_strchr` | ✅ | test_fs.c, test_strings.c |
 | `l_strrchr` | ✅ | test_strings.c |
-| `l_strstr` | ✅ | test_fs.c, test_strings.c, test.c |
-| `l_strcmp` | ✅ | test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
+| `l_strstr` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_strcmp` | ✅ | test.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
 | `l_strncmp` | ✅ | test_strings.c |
 | `l_strcasecmp` | ✅ | test_strings.c |
 | `l_strncasecmp` | ✅ | test_fs.c, test_strings.c |
@@ -1383,7 +1383,7 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_labs` | ✅ | test_strings.c |
 | `l_llabs` | ✅ | test.c |
 | `l_atol` | ✅ | test_strings.c |
-| `l_atoi` | ✅ | test_strings.c, test.c |
+| `l_atoi` | ✅ | test.c, test_strings.c |
 | `l_strtoul` | ✅ | test_strings.c |
 | `l_strtol` | ✅ | test_strings.c |
 | `l_strtoull` | ✅ | test_strings.c |
@@ -1415,8 +1415,8 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_itoa` | ✅ | test_strings.c |
 | **Memory functions** | | |
 | `l_memmove` | ✅ | test_strings.c |
-| `l_memset` | ✅ | test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
-| `l_memcmp` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_utils.c, test.c |
+| `l_memset` | ✅ | test.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
+| `l_memcmp` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_utils.c |
 | `l_memcpy` | ✅ | test_strings.c, test_utils.c |
 | `l_memchr` | ✅ | test_strings.c |
 | `l_memrchr` | ✅ | test_strings.c |
@@ -1437,30 +1437,30 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_vprintf` | ✅ | test_strings.c |
 | `l_fprintf` | ✅ | test_strings.c |
 | **System functions** | | |
-| `l_exit` | ✅ | test_fs.c, test.c |
-| `l_open` | ✅ | test_fs.c, test.c |
-| `l_close` | ✅ | test_fs.c, test_strings.c, test.c |
-| `l_read` | ✅ | test_fs.c, test_strings.c, test.c |
-| `l_write` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_exit` | ✅ | test.c, test_fs.c |
+| `l_open` | ✅ | test.c, test_fs.c |
+| `l_close` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_read` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_write` | ✅ | test.c, test_fs.c, test_strings.c |
 | `l_read_line` | ✅ | test.c |
 | `l_linebuf_init` | ✅ | test_strings.c |
 | `l_linebuf_read` | ✅ | test_strings.c |
 | `l_time` | ✅ | test_utils.c |
-| `l_puts` | ✅ | test_fs.c, test.c |
+| `l_puts` | ✅ | test.c, test_fs.c |
 | `l_exitif` | ✅ | test_fs.c |
-| `l_getenv` | ✅ | gfx_test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_utils.c, test.c |
-| `l_getenv_init` | ✅ | gfx_test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_utils.c, test.c |
+| `l_getenv` | ✅ | gfx_test.c, test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_utils.c |
+| `l_getenv_init` | ✅ | gfx_test.c, test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_utils.c |
 | `l_env_start` | ✅ | test_fs.c |
 | `l_env_next` | ✅ | test_fs.c |
 | `l_env_end` | ✅ | test_fs.c |
 | `l_find_executable` | ✅ | test.c |
 | **Option parsing (single-threaded; state in static variables)** | | |
-| `l_getopt` | ✅ | test_utils.c, test.c |
+| `l_getopt` | ✅ | test.c, test_utils.c |
 | `l_getopt_ctx_init` | ✅ | test_utils.c |
 | `l_getopt_ctx` | ✅ | test_utils.c |
 | **Convenience file openers** | | |
-| `l_open_read` | ✅ | test_fs.c, test.c |
-| `l_open_write` | ✅ | test_fs.c, test.c |
+| `l_open_read` | ✅ | test.c, test_fs.c |
+| `l_open_write` | ✅ | test.c, test_fs.c |
 | `l_open_readwrite` | ✅ | test_fs.c |
 | `l_open_append` | ✅ | test_fs.c |
 | `l_open_trunc` | ✅ | test_fs.c |
@@ -1478,10 +1478,10 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_ansi_color` | ✅ | test_term_gfx.c, test_utils.c |
 | `l_ansi_color_rgb` | ✅ | test_term_gfx.c |
 | **File system functions (cross-platform)** | | |
-| `l_unlink` | ✅ | test_fs.c, test.c |
+| `l_unlink` | ✅ | test.c, test_fs.c |
 | `l_rmdir` | ✅ | test_fs.c |
 | `l_rename` | ✅ | test_fs.c |
-| `l_access` | ✅ | test_fs.c, test.c |
+| `l_access` | ✅ | test.c, test_fs.c |
 | `l_chmod` | ✅ | test_fs.c |
 | `l_symlink` | ✅ | test_fs.c |
 | `l_readlink` | ✅ | test_fs.c |
@@ -1510,8 +1510,8 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_buf_printf` | ✅ | test_utils.c |
 | `l_buf_clear` | ✅ | test_utils.c |
 | `l_buf_free` | ✅ | test_utils.c |
-| **L_Str — fat string (pointer + length) function declarations** | | |
-| `l_str` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
+| **L_Str â€” fat string (pointer + length) function declarations** | | |
+| `l_str` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
 | `l_str_from` | ✅ | test_utils.c |
 | `l_str_null` | ✅ | test_utils.c |
 | `l_str_eq` | ✅ | test_utils.c |
@@ -1573,7 +1573,7 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_base64_decode` | ✅ | test_utils.c |
 | `l_getcwd` | ✅ | test_fs.c |
 | `l_chdir` | ✅ | test_fs.c |
-| `l_pipe` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_pipe` | ✅ | test.c, test_fs.c, test_strings.c |
 | `l_dup` | ✅ | test.c |
 | `l_dup2` | ✅ | test.c |
 | `l_getpid` | ✅ | test.c |

--- a/README.md
+++ b/README.md
@@ -758,7 +758,7 @@ Generated from doc-comments. Run `.\gen-docs.ps1` to regenerate.
 | **Arena function declarations** | | |
 | `l_arena_init` | Allocate an arena of `size` bytes via mmap. On failure, base=NULL. | All |
 | `l_arena_alloc` | Bump-allocate n bytes (8-byte aligned). Returns NULL if arena is full. | All |
-| `l_arena_reset` | Reset used to 0. Memory is NOT freed â€” arena can be reused. | All |
+| `l_arena_reset` | Reset used to 0. Memory is NOT freed — arena can be reused. | All |
 | `l_arena_free` | Free the backing memory. Sets base=NULL. | All |
 | **Buffer function declarations** | | |
 | `l_buf_init` | Zero-initialize a buffer. | All |
@@ -766,7 +766,7 @@ Generated from doc-comments. Run `.\gen-docs.ps1` to regenerate.
 | `l_buf_printf` | Formatted append using l_vsnprintf. Returns bytes written or -1. | All |
 | `l_buf_clear` | Set len=0 (keep allocated memory). | All |
 | `l_buf_free` | Free backing memory and zero the struct. | All |
-| **L_Str â€” fat string (pointer + length) function declarations** | | |
+| **L_Str — fat string (pointer + length) function declarations** | | |
 | `l_str` | Wrap a C string (computes strlen). | All |
 | `l_str_from` | Wrap pointer+length. | All |
 | `l_str_null` | Return null string {NULL, 0}. | All |
@@ -1220,7 +1220,7 @@ Which `l_os.h` functions work on which platform. Generated from code annotations
 | ``l_buf_printf`` | ✅ | ✅ | ✅ |
 | ``l_buf_clear`` | ✅ | ✅ | ✅ |
 | ``l_buf_free`` | ✅ | ✅ | ✅ |
-| **L_Str â€” fat string (pointer + length) function declarations** | | | |
+| **L_Str — fat string (pointer + length) function declarations** | | | |
 | ``l_str`` | ✅ | ✅ | ✅ |
 | ``l_str_from`` | ✅ | ✅ | ✅ |
 | ``l_str_null`` | ✅ | ✅ | ✅ |
@@ -1342,15 +1342,15 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 |----------|--------|-----------|
 | **String functions** | | |
 | `l_wcslen` | ✅ | test_strings.c |
-| `l_strlen` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
-| `l_strcpy` | ✅ | test.c, test_strings.c |
+| `l_strlen` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
+| `l_strcpy` | ✅ | test_strings.c, test.c |
 | `l_strncpy` | ✅ | test_strings.c |
-| `l_strcat` | ✅ | test.c, test_strings.c |
+| `l_strcat` | ✅ | test_strings.c, test.c |
 | `l_strncat` | ✅ | test_strings.c |
 | `l_strchr` | ✅ | test_fs.c, test_strings.c |
 | `l_strrchr` | ✅ | test_strings.c |
-| `l_strstr` | ✅ | test.c, test_fs.c, test_strings.c |
-| `l_strcmp` | ✅ | test.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
+| `l_strstr` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_strcmp` | ✅ | test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
 | `l_strncmp` | ✅ | test_strings.c |
 | `l_strcasecmp` | ✅ | test_strings.c |
 | `l_strncasecmp` | ✅ | test_fs.c, test_strings.c |
@@ -1383,7 +1383,7 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_labs` | ✅ | test_strings.c |
 | `l_llabs` | ✅ | test.c |
 | `l_atol` | ✅ | test_strings.c |
-| `l_atoi` | ✅ | test.c, test_strings.c |
+| `l_atoi` | ✅ | test_strings.c, test.c |
 | `l_strtoul` | ✅ | test_strings.c |
 | `l_strtol` | ✅ | test_strings.c |
 | `l_strtoull` | ✅ | test_strings.c |
@@ -1415,8 +1415,8 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_itoa` | ✅ | test_strings.c |
 | **Memory functions** | | |
 | `l_memmove` | ✅ | test_strings.c |
-| `l_memset` | ✅ | test.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
-| `l_memcmp` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_utils.c |
+| `l_memset` | ✅ | test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
+| `l_memcmp` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_utils.c, test.c |
 | `l_memcpy` | ✅ | test_strings.c, test_utils.c |
 | `l_memchr` | ✅ | test_strings.c |
 | `l_memrchr` | ✅ | test_strings.c |
@@ -1437,30 +1437,30 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_vprintf` | ✅ | test_strings.c |
 | `l_fprintf` | ✅ | test_strings.c |
 | **System functions** | | |
-| `l_exit` | ✅ | test.c, test_fs.c |
-| `l_open` | ✅ | test.c, test_fs.c |
-| `l_close` | ✅ | test.c, test_fs.c, test_strings.c |
-| `l_read` | ✅ | test.c, test_fs.c, test_strings.c |
-| `l_write` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_exit` | ✅ | test_fs.c, test.c |
+| `l_open` | ✅ | test_fs.c, test.c |
+| `l_close` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_read` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_write` | ✅ | test_fs.c, test_strings.c, test.c |
 | `l_read_line` | ✅ | test.c |
 | `l_linebuf_init` | ✅ | test_strings.c |
 | `l_linebuf_read` | ✅ | test_strings.c |
 | `l_time` | ✅ | test_utils.c |
-| `l_puts` | ✅ | test.c, test_fs.c |
+| `l_puts` | ✅ | test_fs.c, test.c |
 | `l_exitif` | ✅ | test_fs.c |
-| `l_getenv` | ✅ | gfx_test.c, test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_utils.c |
-| `l_getenv_init` | ✅ | gfx_test.c, test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_utils.c |
+| `l_getenv` | ✅ | gfx_test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_utils.c, test.c |
+| `l_getenv_init` | ✅ | gfx_test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_utils.c, test.c |
 | `l_env_start` | ✅ | test_fs.c |
 | `l_env_next` | ✅ | test_fs.c |
 | `l_env_end` | ✅ | test_fs.c |
 | `l_find_executable` | ✅ | test.c |
 | **Option parsing (single-threaded; state in static variables)** | | |
-| `l_getopt` | ✅ | test.c, test_utils.c |
+| `l_getopt` | ✅ | test_utils.c, test.c |
 | `l_getopt_ctx_init` | ✅ | test_utils.c |
 | `l_getopt_ctx` | ✅ | test_utils.c |
 | **Convenience file openers** | | |
-| `l_open_read` | ✅ | test.c, test_fs.c |
-| `l_open_write` | ✅ | test.c, test_fs.c |
+| `l_open_read` | ✅ | test_fs.c, test.c |
+| `l_open_write` | ✅ | test_fs.c, test.c |
 | `l_open_readwrite` | ✅ | test_fs.c |
 | `l_open_append` | ✅ | test_fs.c |
 | `l_open_trunc` | ✅ | test_fs.c |
@@ -1478,10 +1478,10 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_ansi_color` | ✅ | test_term_gfx.c, test_utils.c |
 | `l_ansi_color_rgb` | ✅ | test_term_gfx.c |
 | **File system functions (cross-platform)** | | |
-| `l_unlink` | ✅ | test.c, test_fs.c |
+| `l_unlink` | ✅ | test_fs.c, test.c |
 | `l_rmdir` | ✅ | test_fs.c |
 | `l_rename` | ✅ | test_fs.c |
-| `l_access` | ✅ | test.c, test_fs.c |
+| `l_access` | ✅ | test_fs.c, test.c |
 | `l_chmod` | ✅ | test_fs.c |
 | `l_symlink` | ✅ | test_fs.c |
 | `l_readlink` | ✅ | test_fs.c |
@@ -1510,8 +1510,8 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_buf_printf` | ✅ | test_utils.c |
 | `l_buf_clear` | ✅ | test_utils.c |
 | `l_buf_free` | ✅ | test_utils.c |
-| **L_Str â€” fat string (pointer + length) function declarations** | | |
-| `l_str` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
+| **L_Str — fat string (pointer + length) function declarations** | | |
+| `l_str` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
 | `l_str_from` | ✅ | test_utils.c |
 | `l_str_null` | ✅ | test_utils.c |
 | `l_str_eq` | ✅ | test_utils.c |
@@ -1573,7 +1573,7 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_base64_decode` | ✅ | test_utils.c |
 | `l_getcwd` | ✅ | test_fs.c |
 | `l_chdir` | ✅ | test_fs.c |
-| `l_pipe` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_pipe` | ✅ | test_fs.c, test_strings.c, test.c |
 | `l_dup` | ✅ | test.c |
 | `l_dup2` | ✅ | test.c |
 | `l_getpid` | ✅ | test.c |

--- a/l_tls.h
+++ b/l_tls.h
@@ -231,6 +231,15 @@ static inline int l_tls_connect(const char *hostname, int port) {
     SOCKET sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (sock == INVALID_SOCKET) return -1;
 
+    // Apply send/recv timeouts so blocking syscalls (handshake recv/send and
+    // l_tls_recv body reads) cannot hang forever on unresponsive peers.
+    // Winsock SO_RCVTIMEO / SO_SNDTIMEO take a DWORD in milliseconds.
+    // Values chosen to be generous for slow links but short enough that an
+    // unreachable host surfaces an error instead of a ~21 s OS default hang.
+    { DWORD rcv_ms = 15000; DWORD snd_ms = 10000;
+      setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char *)&rcv_ms, (int)sizeof(rcv_ms));
+      setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const char *)&snd_ms, (int)sizeof(snd_ms)); }
+
     struct sockaddr_in sa;
     l_memset(&sa, 0, sizeof(sa));
     sa.sin_family = AF_INET;


### PR DESCRIPTION
## Why

Blocking `recv`/`send` syscalls inside `l_tls_do_handshake` and `l_tls_recv` had no timeouts, so connecting to an unresponsive or slow TLS peer (e.g. `text.npr.org`) would freeze the caller indefinitely. `connect()` itself also inherits the ~21 s Windows default for unreachable hosts. Since Oscan's `osc_tls_connect` is a thin passthrough to `l_tls_connect`, the only place to interpose a timer is here.

## What

In the Windows/SChannel branch of `l_tls_connect`, immediately after `socket()` succeeds, apply:

- `SO_RCVTIMEO = 15000 ms`
- `SO_SNDTIMEO = 10000 ms`

via `setsockopt` (Winsock takes a `DWORD` of milliseconds). The existing `if (r <= 0) return -1;` paths in the handshake loop and `l_tls_recv` already translate a timed-out syscall into a clean connection/read failure, so no further changes are needed.

## Notes

- Change is confined to `#ifdef _WIN32` -- TLS is currently Windows-only, Linux/WASI branches are stubs.
- Timeout values are generous enough for slow links but short enough that unreachable hosts surface a clear error instead of an OS-default hang.
- Verified with full cross-platform CI (`ci.ps1`): Windows, Linux gcc/clang, ARM gcc/clang, AArch64 gcc/clang, RISC-V gcc/clang all pass.