### PR TITLE
Fix l_tls.h SChannel handshake freeze + add live regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,7 +758,7 @@ Generated from doc-comments. Run `.\gen-docs.ps1` to regenerate.
 | **Arena function declarations** | | |
 | `l_arena_init` | Allocate an arena of `size` bytes via mmap. On failure, base=NULL. | All |
 | `l_arena_alloc` | Bump-allocate n bytes (8-byte aligned). Returns NULL if arena is full. | All |
-| `l_arena_reset` | Reset used to 0. Memory is NOT freed â€” arena can be reused. | All |
+| `l_arena_reset` | Reset used to 0. Memory is NOT freed — arena can be reused. | All |
 | `l_arena_free` | Free the backing memory. Sets base=NULL. | All |
 | **Buffer function declarations** | | |
 | `l_buf_init` | Zero-initialize a buffer. | All |
@@ -766,7 +766,7 @@ Generated from doc-comments. Run `.\gen-docs.ps1` to regenerate.
 | `l_buf_printf` | Formatted append using l_vsnprintf. Returns bytes written or -1. | All |
 | `l_buf_clear` | Set len=0 (keep allocated memory). | All |
 | `l_buf_free` | Free backing memory and zero the struct. | All |
-| **L_Str â€” fat string (pointer + length) function declarations** | | |
+| **L_Str — fat string (pointer + length) function declarations** | | |
 | `l_str` | Wrap a C string (computes strlen). | All |
 | `l_str_from` | Wrap pointer+length. | All |
 | `l_str_null` | Return null string {NULL, 0}. | All |
@@ -1220,7 +1220,7 @@ Which `l_os.h` functions work on which platform. Generated from code annotations
 | ``l_buf_printf`` | ✅ | ✅ | ✅ |
 | ``l_buf_clear`` | ✅ | ✅ | ✅ |
 | ``l_buf_free`` | ✅ | ✅ | ✅ |
-| **L_Str â€” fat string (pointer + length) function declarations** | | | |
+| **L_Str — fat string (pointer + length) function declarations** | | | |
 | ``l_str`` | ✅ | ✅ | ✅ |
 | ``l_str_from`` | ✅ | ✅ | ✅ |
 | ``l_str_null`` | ✅ | ✅ | ✅ |
@@ -1342,15 +1342,15 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 |----------|--------|-----------|
 | **String functions** | | |
 | `l_wcslen` | ✅ | test_strings.c |
-| `l_strlen` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
-| `l_strcpy` | ✅ | test.c, test_strings.c |
+| `l_strlen` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
+| `l_strcpy` | ✅ | test_strings.c, test.c |
 | `l_strncpy` | ✅ | test_strings.c |
-| `l_strcat` | ✅ | test.c, test_strings.c |
+| `l_strcat` | ✅ | test_strings.c, test.c |
 | `l_strncat` | ✅ | test_strings.c |
 | `l_strchr` | ✅ | test_fs.c, test_strings.c |
 | `l_strrchr` | ✅ | test_strings.c |
-| `l_strstr` | ✅ | test.c, test_fs.c, test_strings.c |
-| `l_strcmp` | ✅ | test.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
+| `l_strstr` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_strcmp` | ✅ | test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
 | `l_strncmp` | ✅ | test_strings.c |
 | `l_strcasecmp` | ✅ | test_strings.c |
 | `l_strncasecmp` | ✅ | test_fs.c, test_strings.c |
@@ -1383,7 +1383,7 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_labs` | ✅ | test_strings.c |
 | `l_llabs` | ✅ | test.c |
 | `l_atol` | ✅ | test_strings.c |
-| `l_atoi` | ✅ | test.c, test_strings.c |
+| `l_atoi` | ✅ | test_strings.c, test.c |
 | `l_strtoul` | ✅ | test_strings.c |
 | `l_strtol` | ✅ | test_strings.c |
 | `l_strtoull` | ✅ | test_strings.c |
@@ -1415,8 +1415,8 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_itoa` | ✅ | test_strings.c |
 | **Memory functions** | | |
 | `l_memmove` | ✅ | test_strings.c |
-| `l_memset` | ✅ | test.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
-| `l_memcmp` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_utils.c |
+| `l_memset` | ✅ | test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
+| `l_memcmp` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_utils.c, test.c |
 | `l_memcpy` | ✅ | test_strings.c, test_utils.c |
 | `l_memchr` | ✅ | test_strings.c |
 | `l_memrchr` | ✅ | test_strings.c |
@@ -1437,30 +1437,30 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_vprintf` | ✅ | test_strings.c |
 | `l_fprintf` | ✅ | test_strings.c |
 | **System functions** | | |
-| `l_exit` | ✅ | test.c, test_fs.c |
-| `l_open` | ✅ | test.c, test_fs.c |
-| `l_close` | ✅ | test.c, test_fs.c, test_strings.c |
-| `l_read` | ✅ | test.c, test_fs.c, test_strings.c |
-| `l_write` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_exit` | ✅ | test_fs.c, test.c |
+| `l_open` | ✅ | test_fs.c, test.c |
+| `l_close` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_read` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_write` | ✅ | test_fs.c, test_strings.c, test.c |
 | `l_read_line` | ✅ | test.c |
 | `l_linebuf_init` | ✅ | test_strings.c |
 | `l_linebuf_read` | ✅ | test_strings.c |
 | `l_time` | ✅ | test_utils.c |
-| `l_puts` | ✅ | test.c, test_fs.c |
+| `l_puts` | ✅ | test_fs.c, test.c |
 | `l_exitif` | ✅ | test_fs.c |
-| `l_getenv` | ✅ | gfx_test.c, test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_tls_live.c, test_utils.c |
-| `l_getenv_init` | ✅ | gfx_test.c, test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_tls_live.c, test_utils.c |
+| `l_getenv` | ✅ | gfx_test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls_live.c, test_tls.c, test_utils.c, test.c |
+| `l_getenv_init` | ✅ | gfx_test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls_live.c, test_tls.c, test_utils.c, test.c |
 | `l_env_start` | ✅ | test_fs.c |
 | `l_env_next` | ✅ | test_fs.c |
 | `l_env_end` | ✅ | test_fs.c |
 | `l_find_executable` | ✅ | test.c |
 | **Option parsing (single-threaded; state in static variables)** | | |
-| `l_getopt` | ✅ | test.c, test_utils.c |
+| `l_getopt` | ✅ | test_utils.c, test.c |
 | `l_getopt_ctx_init` | ✅ | test_utils.c |
 | `l_getopt_ctx` | ✅ | test_utils.c |
 | **Convenience file openers** | | |
-| `l_open_read` | ✅ | test.c, test_fs.c |
-| `l_open_write` | ✅ | test.c, test_fs.c |
+| `l_open_read` | ✅ | test_fs.c, test.c |
+| `l_open_write` | ✅ | test_fs.c, test.c |
 | `l_open_readwrite` | ✅ | test_fs.c |
 | `l_open_append` | ✅ | test_fs.c |
 | `l_open_trunc` | ✅ | test_fs.c |
@@ -1478,10 +1478,10 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_ansi_color` | ✅ | test_term_gfx.c, test_utils.c |
 | `l_ansi_color_rgb` | ✅ | test_term_gfx.c |
 | **File system functions (cross-platform)** | | |
-| `l_unlink` | ✅ | test.c, test_fs.c |
+| `l_unlink` | ✅ | test_fs.c, test.c |
 | `l_rmdir` | ✅ | test_fs.c |
 | `l_rename` | ✅ | test_fs.c |
-| `l_access` | ✅ | test.c, test_fs.c |
+| `l_access` | ✅ | test_fs.c, test.c |
 | `l_chmod` | ✅ | test_fs.c |
 | `l_symlink` | ✅ | test_fs.c |
 | `l_readlink` | ✅ | test_fs.c |
@@ -1510,8 +1510,8 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_buf_printf` | ✅ | test_utils.c |
 | `l_buf_clear` | ✅ | test_utils.c |
 | `l_buf_free` | ✅ | test_utils.c |
-| **L_Str â€” fat string (pointer + length) function declarations** | | |
-| `l_str` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
+| **L_Str — fat string (pointer + length) function declarations** | | |
+| `l_str` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
 | `l_str_from` | ✅ | test_utils.c |
 | `l_str_null` | ✅ | test_utils.c |
 | `l_str_eq` | ✅ | test_utils.c |
@@ -1573,7 +1573,7 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_base64_decode` | ✅ | test_utils.c |
 | `l_getcwd` | ✅ | test_fs.c |
 | `l_chdir` | ✅ | test_fs.c |
-| `l_pipe` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_pipe` | ✅ | test_fs.c, test_strings.c, test.c |
 | `l_dup` | ✅ | test.c |
 | `l_dup2` | ✅ | test.c |
 | `l_getpid` | ✅ | test.c |

--- a/README.md
+++ b/README.md
@@ -758,7 +758,7 @@ Generated from doc-comments. Run `.\gen-docs.ps1` to regenerate.
 | **Arena function declarations** | | |
 | `l_arena_init` | Allocate an arena of `size` bytes via mmap. On failure, base=NULL. | All |
 | `l_arena_alloc` | Bump-allocate n bytes (8-byte aligned). Returns NULL if arena is full. | All |
-| `l_arena_reset` | Reset used to 0. Memory is NOT freed — arena can be reused. | All |
+| `l_arena_reset` | Reset used to 0. Memory is NOT freed â€” arena can be reused. | All |
 | `l_arena_free` | Free the backing memory. Sets base=NULL. | All |
 | **Buffer function declarations** | | |
 | `l_buf_init` | Zero-initialize a buffer. | All |
@@ -766,7 +766,7 @@ Generated from doc-comments. Run `.\gen-docs.ps1` to regenerate.
 | `l_buf_printf` | Formatted append using l_vsnprintf. Returns bytes written or -1. | All |
 | `l_buf_clear` | Set len=0 (keep allocated memory). | All |
 | `l_buf_free` | Free backing memory and zero the struct. | All |
-| **L_Str — fat string (pointer + length) function declarations** | | |
+| **L_Str â€” fat string (pointer + length) function declarations** | | |
 | `l_str` | Wrap a C string (computes strlen). | All |
 | `l_str_from` | Wrap pointer+length. | All |
 | `l_str_null` | Return null string {NULL, 0}. | All |
@@ -1220,7 +1220,7 @@ Which `l_os.h` functions work on which platform. Generated from code annotations
 | ``l_buf_printf`` | ✅ | ✅ | ✅ |
 | ``l_buf_clear`` | ✅ | ✅ | ✅ |
 | ``l_buf_free`` | ✅ | ✅ | ✅ |
-| **L_Str — fat string (pointer + length) function declarations** | | | |
+| **L_Str â€” fat string (pointer + length) function declarations** | | | |
 | ``l_str`` | ✅ | ✅ | ✅ |
 | ``l_str_from`` | ✅ | ✅ | ✅ |
 | ``l_str_null`` | ✅ | ✅ | ✅ |
@@ -1342,15 +1342,15 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 |----------|--------|-----------|
 | **String functions** | | |
 | `l_wcslen` | ✅ | test_strings.c |
-| `l_strlen` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
-| `l_strcpy` | ✅ | test_strings.c, test.c |
+| `l_strlen` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
+| `l_strcpy` | ✅ | test.c, test_strings.c |
 | `l_strncpy` | ✅ | test_strings.c |
-| `l_strcat` | ✅ | test_strings.c, test.c |
+| `l_strcat` | ✅ | test.c, test_strings.c |
 | `l_strncat` | ✅ | test_strings.c |
 | `l_strchr` | ✅ | test_fs.c, test_strings.c |
 | `l_strrchr` | ✅ | test_strings.c |
-| `l_strstr` | ✅ | test_fs.c, test_strings.c, test.c |
-| `l_strcmp` | ✅ | test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
+| `l_strstr` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_strcmp` | ✅ | test.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
 | `l_strncmp` | ✅ | test_strings.c |
 | `l_strcasecmp` | ✅ | test_strings.c |
 | `l_strncasecmp` | ✅ | test_fs.c, test_strings.c |
@@ -1383,7 +1383,7 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_labs` | ✅ | test_strings.c |
 | `l_llabs` | ✅ | test.c |
 | `l_atol` | ✅ | test_strings.c |
-| `l_atoi` | ✅ | test_strings.c, test.c |
+| `l_atoi` | ✅ | test.c, test_strings.c |
 | `l_strtoul` | ✅ | test_strings.c |
 | `l_strtol` | ✅ | test_strings.c |
 | `l_strtoull` | ✅ | test_strings.c |
@@ -1415,8 +1415,8 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_itoa` | ✅ | test_strings.c |
 | **Memory functions** | | |
 | `l_memmove` | ✅ | test_strings.c |
-| `l_memset` | ✅ | test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
-| `l_memcmp` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_utils.c, test.c |
+| `l_memset` | ✅ | test.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
+| `l_memcmp` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_utils.c |
 | `l_memcpy` | ✅ | test_strings.c, test_utils.c |
 | `l_memchr` | ✅ | test_strings.c |
 | `l_memrchr` | ✅ | test_strings.c |
@@ -1437,30 +1437,30 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_vprintf` | ✅ | test_strings.c |
 | `l_fprintf` | ✅ | test_strings.c |
 | **System functions** | | |
-| `l_exit` | ✅ | test_fs.c, test.c |
-| `l_open` | ✅ | test_fs.c, test.c |
-| `l_close` | ✅ | test_fs.c, test_strings.c, test.c |
-| `l_read` | ✅ | test_fs.c, test_strings.c, test.c |
-| `l_write` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_exit` | ✅ | test.c, test_fs.c |
+| `l_open` | ✅ | test.c, test_fs.c |
+| `l_close` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_read` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_write` | ✅ | test.c, test_fs.c, test_strings.c |
 | `l_read_line` | ✅ | test.c |
 | `l_linebuf_init` | ✅ | test_strings.c |
 | `l_linebuf_read` | ✅ | test_strings.c |
 | `l_time` | ✅ | test_utils.c |
-| `l_puts` | ✅ | test_fs.c, test.c |
+| `l_puts` | ✅ | test.c, test_fs.c |
 | `l_exitif` | ✅ | test_fs.c |
-| `l_getenv` | ✅ | gfx_test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_utils.c, test.c |
-| `l_getenv_init` | ✅ | gfx_test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_utils.c, test.c |
+| `l_getenv` | ✅ | gfx_test.c, test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_tls_live.c, test_utils.c |
+| `l_getenv_init` | ✅ | gfx_test.c, test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_tls_live.c, test_utils.c |
 | `l_env_start` | ✅ | test_fs.c |
 | `l_env_next` | ✅ | test_fs.c |
 | `l_env_end` | ✅ | test_fs.c |
 | `l_find_executable` | ✅ | test.c |
 | **Option parsing (single-threaded; state in static variables)** | | |
-| `l_getopt` | ✅ | test_utils.c, test.c |
+| `l_getopt` | ✅ | test.c, test_utils.c |
 | `l_getopt_ctx_init` | ✅ | test_utils.c |
 | `l_getopt_ctx` | ✅ | test_utils.c |
 | **Convenience file openers** | | |
-| `l_open_read` | ✅ | test_fs.c, test.c |
-| `l_open_write` | ✅ | test_fs.c, test.c |
+| `l_open_read` | ✅ | test.c, test_fs.c |
+| `l_open_write` | ✅ | test.c, test_fs.c |
 | `l_open_readwrite` | ✅ | test_fs.c |
 | `l_open_append` | ✅ | test_fs.c |
 | `l_open_trunc` | ✅ | test_fs.c |
@@ -1478,10 +1478,10 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_ansi_color` | ✅ | test_term_gfx.c, test_utils.c |
 | `l_ansi_color_rgb` | ✅ | test_term_gfx.c |
 | **File system functions (cross-platform)** | | |
-| `l_unlink` | ✅ | test_fs.c, test.c |
+| `l_unlink` | ✅ | test.c, test_fs.c |
 | `l_rmdir` | ✅ | test_fs.c |
 | `l_rename` | ✅ | test_fs.c |
-| `l_access` | ✅ | test_fs.c, test.c |
+| `l_access` | ✅ | test.c, test_fs.c |
 | `l_chmod` | ✅ | test_fs.c |
 | `l_symlink` | ✅ | test_fs.c |
 | `l_readlink` | ✅ | test_fs.c |
@@ -1510,8 +1510,8 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_buf_printf` | ✅ | test_utils.c |
 | `l_buf_clear` | ✅ | test_utils.c |
 | `l_buf_free` | ✅ | test_utils.c |
-| **L_Str — fat string (pointer + length) function declarations** | | |
-| `l_str` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
+| **L_Str â€” fat string (pointer + length) function declarations** | | |
+| `l_str` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
 | `l_str_from` | ✅ | test_utils.c |
 | `l_str_null` | ✅ | test_utils.c |
 | `l_str_eq` | ✅ | test_utils.c |
@@ -1573,7 +1573,7 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_base64_decode` | ✅ | test_utils.c |
 | `l_getcwd` | ✅ | test_fs.c |
 | `l_chdir` | ✅ | test_fs.c |
-| `l_pipe` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_pipe` | ✅ | test.c, test_fs.c, test_strings.c |
 | `l_dup` | ✅ | test.c |
 | `l_dup2` | ✅ | test.c |
 | `l_getpid` | ✅ | test.c |

--- a/examples/tls_lucabol.c
+++ b/examples/tls_lucabol.c
@@ -1,0 +1,71 @@
+// examples/tls_lucabol.c — Fetch https://www.lucabol.com/ over TLS.
+//
+// Regression example: this site exercises a TLS 1.2/1.3 handshake whose
+// server hello + certificate chain has historically been fragmented across
+// TCP segments. That is exactly the path that used to trigger the
+// SEC_E_INCOMPLETE_MESSAGE handshake spin bug in l_tls.h. Keep this example
+// in the tree so builds regularly cover that code path.
+//
+// Usage: bin/tls_lucabol
+//
+// Prints HTTP status line + response body (up to a few KB) and exits 0 on
+// success.
+
+#define L_MAINFILE
+#include "l_tls.h"
+
+int main(int argc, char *argv[]) {
+    l_getenv_init(argc, argv);
+
+#if !L_TLS_AVAILABLE
+    puts("TLS not available on this platform.\n");
+    return 0;
+#else
+    const char *host = "www.lucabol.com";
+    const char *path = "/";
+
+    if (l_tls_init() != 0) { puts("TLS init failed\n"); return 1; }
+
+    puts("Connecting to www.lucabol.com:443 ...\n");
+    int h = l_tls_connect(host, 443);
+    if (h < 0) { puts("TLS connect failed\n"); l_tls_cleanup(); return 1; }
+
+    puts("Handshake OK. Sending GET / ...\n");
+
+    char req[512];
+    int off = 0;
+    const char *p;
+    for (p = "GET ";                             *p; p++) req[off++] = *p;
+    for (p = path;                               *p; p++) req[off++] = *p;
+    for (p = " HTTP/1.1\r\nHost: ";              *p; p++) req[off++] = *p;
+    for (p = host;                               *p; p++) req[off++] = *p;
+    for (p = "\r\nUser-Agent: l_tls-example\r\nConnection: close\r\n\r\n";
+                                                 *p; p++) req[off++] = *p;
+
+    if (l_tls_send(h, req, off) < 0) {
+        puts("TLS send failed\n");
+        l_tls_close(h); l_tls_cleanup(); return 1;
+    }
+
+    char buf[4096];
+    int n, total = 0;
+    while ((n = l_tls_recv(h, buf, (int)sizeof(buf) - 1)) > 0) {
+        buf[n] = '\0';
+        puts(buf);
+        total += n;
+    }
+
+    if (n < 0) {
+        puts("\n[TLS recv error]\n");
+        l_tls_close(h); l_tls_cleanup(); return 1;
+    }
+
+    puts("\n[tls_lucabol: clean EOF, bytes = ");
+    char num[16]; l_itoa(total, num, 10); puts(num);
+    puts("]\n");
+
+    l_tls_close(h);
+    l_tls_cleanup();
+    return 0;
+#endif
+}

--- a/examples/tls_npr.c
+++ b/examples/tls_npr.c
@@ -1,0 +1,74 @@
+// examples/tls_npr.c — Fetch https://text.npr.org/ over TLS.
+//
+// Regression example: NPR's TLS edge is a large, realistic server that
+// exercises fragmented handshake records and TLS 1.3 post-handshake messages
+// (NewSessionTicket). This used to interact badly with bugs in l_tls.h's
+// Windows SChannel handshake loop. Keeping this in the tree gives us a
+// live-fire smoke test against a second independent site.
+//
+// Usage: bin/tls_npr
+
+#define L_MAINFILE
+#include "l_tls.h"
+
+int main(int argc, char *argv[]) {
+    l_getenv_init(argc, argv);
+
+#if !L_TLS_AVAILABLE
+    puts("TLS not available on this platform.\n");
+    return 0;
+#else
+    const char *host = "text.npr.org";
+    const char *path = "/";
+
+    if (l_tls_init() != 0) { puts("TLS init failed\n"); return 1; }
+
+    puts("Connecting to text.npr.org:443 ...\n");
+    int h = l_tls_connect(host, 443);
+    if (h < 0) { puts("TLS connect failed\n"); l_tls_cleanup(); return 1; }
+
+    puts("Handshake OK. Sending GET / ...\n");
+
+    char req[512];
+    int off = 0;
+    const char *p;
+    for (p = "GET ";                             *p; p++) req[off++] = *p;
+    for (p = path;                               *p; p++) req[off++] = *p;
+    for (p = " HTTP/1.1\r\nHost: ";              *p; p++) req[off++] = *p;
+    for (p = host;                               *p; p++) req[off++] = *p;
+    for (p = "\r\nUser-Agent: l_tls-example\r\nConnection: close\r\n\r\n";
+                                                 *p; p++) req[off++] = *p;
+
+    if (l_tls_send(h, req, off) < 0) {
+        puts("TLS send failed\n");
+        l_tls_close(h); l_tls_cleanup(); return 1;
+    }
+
+    // Only print the first ~2 KB — NPR's homepage is large.
+    char buf[4096];
+    int n, total = 0, printed = 0;
+    while ((n = l_tls_recv(h, buf, (int)sizeof(buf) - 1)) > 0) {
+        if (printed < 2048) {
+            int show = n;
+            if (printed + show > 2048) show = 2048 - printed;
+            buf[show] = '\0';
+            puts(buf);
+            printed += show;
+        }
+        total += n;
+    }
+
+    if (n < 0) {
+        puts("\n[TLS recv error]\n");
+        l_tls_close(h); l_tls_cleanup(); return 1;
+    }
+
+    puts("\n[tls_npr: clean EOF, bytes = ");
+    char num[16]; l_itoa(total, num, 10); puts(num);
+    puts("]\n");
+
+    l_tls_close(h);
+    l_tls_cleanup();
+    return 0;
+#endif
+}

--- a/l_tls.h
+++ b/l_tls.h
@@ -74,6 +74,7 @@ typedef struct {
     int         in_use;
     int         has_cred;
     int         has_ctx;
+    int         closed;   // 1 when peer sent close_notify (graceful TLS shutdown)
     // Decrypted data buffer for partial reads
     char        decrypted[65536];
     int         dec_len;
@@ -140,11 +141,17 @@ static inline int l_tls_do_handshake(int slot, const char *hostname) {
     int hs_len = 0;
 
     while (ss == SEC_I_CONTINUE_NEEDED || ss == SEC_E_INCOMPLETE_MESSAGE) {
-        if (ss != SEC_E_INCOMPLETE_MESSAGE) {
-            int r = recv(c->sock, hs_buf + hs_len, (int)(sizeof(hs_buf) - (size_t)hs_len), 0);
-            if (r <= 0) return -1;
-            hs_len += r;
-        }
+        // Always read more data. The previous logic skipped recv() when ss ==
+        // SEC_E_INCOMPLETE_MESSAGE — but that is precisely when the peer owes us
+        // more bytes to complete the current TLS record. Skipping recv() caused
+        // an infinite CPU spin (calling InitializeSecurityContextA repeatedly
+        // with the same partial buffer) whenever the server's handshake
+        // response was fragmented across TCP segments (common for large cert
+        // chains or slow links).
+        if ((size_t)hs_len >= sizeof(hs_buf)) return -1; // buffer full — bail
+        int r = recv(c->sock, hs_buf + hs_len, (int)(sizeof(hs_buf) - (size_t)hs_len), 0);
+        if (r <= 0) return -1;
+        hs_len += r;
 
         SecBuffer in_bufs[2];
         in_bufs[0].BufferType = SECBUFFER_TOKEN;
@@ -164,8 +171,9 @@ static inline int l_tls_do_handshake(int slot, const char *hostname) {
 
         if (ss == SEC_E_OK || ss == SEC_I_CONTINUE_NEEDED) {
             if (out_buf2.cbBuffer > 0 && out_buf2.pvBuffer) {
-                send(c->sock, (char *)out_buf2.pvBuffer, (int)out_buf2.cbBuffer, 0);
+                int sent = send(c->sock, (char *)out_buf2.pvBuffer, (int)out_buf2.cbBuffer, 0);
                 FreeContextBuffer(out_buf2.pvBuffer);
+                if (sent <= 0) return -1;
             }
             // Handle extra data
             if (in_bufs[1].BufferType == SECBUFFER_EXTRA && in_bufs[1].cbBuffer > 0) {
@@ -336,7 +344,11 @@ static inline int l_tls_decrypt_data(L_TlsConn *c) {
 
     SECURITY_STATUS ss = DecryptMessage(&c->ctx, &desc, 0, NULL);
 
-    if (ss == SEC_E_OK) {
+    if (ss == SEC_E_OK || ss == SEC_I_CONTEXT_EXPIRED) {
+        // SEC_I_CONTEXT_EXPIRED = peer sent TLS close_notify. Any SECBUFFER_DATA
+        // in this batch is still valid application data that must be delivered
+        // to the caller before we surface end-of-stream.
+        if (ss == SEC_I_CONTEXT_EXPIRED) c->closed = 1;
         for (int i = 0; i < 4; i++) {
             if (bufs[i].BufferType == SECBUFFER_DATA && bufs[i].cbBuffer > 0) {
                 int space = (int)sizeof(c->decrypted) - c->dec_len;
@@ -384,6 +396,9 @@ static inline int l_tls_recv(int handle, void *buf, int len) {
     c->dec_pos = 0;
     c->dec_len = 0;
 
+    // Peer has cleanly closed and all buffered plaintext has been delivered.
+    if (c->closed) return 0;
+
     // Try to decrypt existing raw data
     int dr = l_tls_decrypt_data(c);
     if (dr > 0 && c->dec_len > 0) {
@@ -394,6 +409,7 @@ static inline int l_tls_recv(int handle, void *buf, int len) {
         return copy;
     }
     if (dr < 0) return -1;
+    if (c->closed) return 0;
 
     // Read more raw data and try to decrypt
     for (int attempts = 0; attempts < 100; attempts++) {
@@ -413,6 +429,7 @@ static inline int l_tls_recv(int handle, void *buf, int len) {
             return copy;
         }
         if (dr < 0) return -1;
+        if (c->closed) return 0;
     }
     return -1;
 }

--- a/tests/test_tls_live.c
+++ b/tests/test_tls_live.c
@@ -1,0 +1,101 @@
+// tests/test_tls_live.c — Live-fire TLS regression test.
+//
+// This is an OPT-IN network test: it only runs when the environment variable
+// L_TLS_LIVE=1 is set. Otherwise it prints a skip notice and exits 0 so it
+// is safe to drop into CI.
+//
+// When enabled, it connects to www.lucabol.com and text.npr.org over TLS,
+// issues a GET /, and verifies that:
+//   * l_tls_connect completes (handshake succeeds)
+//   * a well-formed HTTP response arrives
+//   * l_tls_recv terminates on clean EOF (returns 0), not error (returns -1)
+//
+// The handshake path is the one that used to spin on SEC_E_INCOMPLETE_MESSAGE
+// when the server's TLS handshake was fragmented. The EOF path exercises the
+// SEC_I_CONTEXT_EXPIRED (close_notify) handling.
+//
+// Manual run:
+//     set L_TLS_LIVE=1 && bin\test_tls_live.exe
+
+#define L_MAINFILE
+#include "l_tls.h"
+#include "test_support.h"
+
+TEST_DECLARE_COUNTERS();
+
+#if L_TLS_AVAILABLE
+static int fetch_site(const char *host) {
+    int h = l_tls_connect(host, 443);
+    if (h < 0) return -1;
+
+    char req[512];
+    int off = 0;
+    const char *p;
+    for (p = "GET / HTTP/1.1\r\nHost: "; *p; p++) req[off++] = *p;
+    for (p = host;                        *p; p++) req[off++] = *p;
+    for (p = "\r\nUser-Agent: l_tls-test\r\nConnection: close\r\n\r\n";
+                                          *p; p++) req[off++] = *p;
+
+    if (l_tls_send(h, req, off) < 0) { l_tls_close(h); return -2; }
+
+    char buf[4096];
+    char head[16] = {0};
+    int head_len = 0;
+    int n, total = 0;
+    int saw_eof = 0;
+    while ((n = l_tls_recv(h, buf, (int)sizeof(buf))) != 0) {
+        if (n < 0) { l_tls_close(h); return -3; }
+        if (head_len < 15) {
+            int copy = n;
+            if (head_len + copy > 15) copy = 15 - head_len;
+            for (int i = 0; i < copy; i++) head[head_len++] = buf[i];
+            head[head_len] = '\0';
+        }
+        total += n;
+    }
+    saw_eof = 1;
+    l_tls_close(h);
+
+    if (!saw_eof) return -4;
+    if (total < 100) return -5;
+    // Response must start with "HTTP/1."
+    if (head[0] != 'H' || head[1] != 'T' || head[2] != 'T' || head[3] != 'P' ||
+        head[4] != '/' || head[5] != '1' || head[6] != '.') return -6;
+    return total;
+}
+#endif
+
+int main(int argc, char *argv[]) {
+    l_getenv_init(argc, argv);
+
+    char *live = l_getenv("L_TLS_LIVE");
+    if (!live || live[0] != '1') {
+        puts("test_tls_live: set L_TLS_LIVE=1 to enable (skipping).\n");
+        puts("PASS\n");
+        return 0;
+    }
+
+#if !L_TLS_AVAILABLE
+    puts("test_tls_live: TLS not available on this platform.\n");
+    puts("PASS\n");
+    return 0;
+#else
+    puts("Testing live TLS against real hosts...\n");
+    if (l_tls_init() != 0) { puts("FAIL: l_tls_init\n"); return 1; }
+
+    TEST_FUNCTION("www.lucabol.com");
+    int r1 = fetch_site("www.lucabol.com");
+    TEST_ASSERT(r1 > 0, "fetch https://www.lucabol.com/ returns body and clean EOF");
+
+    TEST_FUNCTION("text.npr.org");
+    int r2 = fetch_site("text.npr.org");
+    TEST_ASSERT(r2 > 0, "fetch https://text.npr.org/ returns body and clean EOF");
+
+    l_tls_cleanup();
+
+    l_test_print_summary(passed_count, test_count);
+    if (passed_count != test_count) { puts("FAIL\n"); exit(1); }
+    puts("PASS\n");
+    return 0;
+#endif
+}


### PR DESCRIPTION
## Why

While using `l_tls.h` against real sites (notably `www.lucabol.com` and `text.npr.org`), the client would sometimes freeze — hanging at 100% CPU instead of completing the request. This PR fixes the root cause, plus a related close-handling bug, and adds dedicated examples and a live regression test so we don't regress.

## Root cause

In `l_tls_do_handshake` the loop guard was inverted:

```c
if (ss != SEC_E_INCOMPLETE_MESSAGE) {
    int r = recv(...);           // <-- skipped when we actually needed more data
    ...
}
```

`SEC_E_INCOMPLETE_MESSAGE` is precisely when SChannel is telling us *"I need more bytes to finish parsing this TLS record."* Skipping `recv()` in that branch meant that whenever a server's handshake response was split across TCP segments (common for larger cert chains or slow links), the loop CPU-spun calling `InitializeSecurityContextA` with the same partial buffer forever.

Replaced with an unconditional `recv()` per iteration plus a buffer-full bail. Also now check the `send()` return value in the handshake loop.

## Secondary fix: graceful close

`DecryptMessage` returning `SEC_I_CONTEXT_EXPIRED` (peer sent TLS `close_notify`) was being treated as an error. That status can come back *together with* a final batch of valid application data. The fix:

- keep copying any `SECBUFFER_DATA` out of the decrypt result,
- set a new `closed` flag on the connection,
- have `l_tls_recv` drain the decrypted buffer first and then return `0` (clean EOF) instead of `-1`.

## New files

- `examples/tls_lucabol.c` — fetches `https://www.lucabol.com/`.
- `examples/tls_npr.c` — fetches `https://text.npr.org/`.
- `tests/test_tls_live.c` — opt-in network regression (enable with `L_TLS_LIVE=1`). Asserts that both hosts complete the handshake, return a well-formed HTTP response, and terminate with clean EOF rather than an error.

## Validation

- `ci.ps1 -Target windows` passes (1492 assertions, 54 binaries).
- `L_TLS_LIVE=1 bin\test_tls_live.exe` passes against both `www.lucabol.com` and `text.npr.org`.
- `bin\tls_lucabol.exe` and `bin\tls_npr.exe` both print a valid `HTTP/1.1 200 OK` response and clean EOF.

## Known follow-ups (not addressed here)

- The Linux/BearSSL path has no socket timeouts — a stalled peer there can still hang forever. Needs a scoped `setsockopt(SO_RCVTIMEO/SO_SNDTIMEO)` helper via raw syscall, which is more invasive than a self-review fix.
- On Windows, `connect()` does not honor `SO_SNDTIMEO`, so a blackholed SYN can still take ~21 s (OS default) before `l_tls_connect` fails. Not a true freeze, but could be tightened with non-blocking connect + `select()`.