### PR TITLE
Add l_set_exe_icon to patch executable icons on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,7 @@ Generated from doc-comments. Run `.\gen-docs.ps1` to regenerate.
 | `l_file_size` | Returns the size of a file in bytes, or -1 on error. | All |
 | `l_read_all` | Reads exactly count bytes, retrying on short reads. Returns total bytes read, 0 on EOF, or negative on error. | All |
 | `l_write_all` | Writes exactly count bytes, retrying on short writes. Returns total bytes written, or negative on error. | All |
+| `l_set_exe_icon` | Sets the icon of an executable file from an .ico file on disk. | All |
 | `l_opendir` | Opens a directory for reading. Returns 0 on success, -1 on error. | All |
 | `l_readdir` | Reads the next directory entry. Returns pointer to L_DirEntry or NULL when done. | All |
 | `l_closedir` | Closes a directory handle. | All |
@@ -758,7 +759,7 @@ Generated from doc-comments. Run `.\gen-docs.ps1` to regenerate.
 | **Arena function declarations** | | |
 | `l_arena_init` | Allocate an arena of `size` bytes via mmap. On failure, base=NULL. | All |
 | `l_arena_alloc` | Bump-allocate n bytes (8-byte aligned). Returns NULL if arena is full. | All |
-| `l_arena_reset` | Reset used to 0. Memory is NOT freed — arena can be reused. | All |
+| `l_arena_reset` | Reset used to 0. Memory is NOT freed â€” arena can be reused. | All |
 | `l_arena_free` | Free the backing memory. Sets base=NULL. | All |
 | **Buffer function declarations** | | |
 | `l_buf_init` | Zero-initialize a buffer. | All |
@@ -766,7 +767,7 @@ Generated from doc-comments. Run `.\gen-docs.ps1` to regenerate.
 | `l_buf_printf` | Formatted append using l_vsnprintf. Returns bytes written or -1. | All |
 | `l_buf_clear` | Set len=0 (keep allocated memory). | All |
 | `l_buf_free` | Free backing memory and zero the struct. | All |
-| **L_Str — fat string (pointer + length) function declarations** | | |
+| **L_Str â€” fat string (pointer + length) function declarations** | | |
 | `l_str` | Wrap a C string (computes strlen). | All |
 | `l_str_from` | Wrap pointer+length. | All |
 | `l_str_null` | Return null string {NULL, 0}. | All |
@@ -1203,6 +1204,7 @@ Which `l_os.h` functions work on which platform. Generated from code annotations
 | ``l_file_size`` | ✅ | ✅ | ✅ |
 | ``l_read_all`` | ✅ | ✅ | ✅ |
 | ``l_write_all`` | ✅ | ✅ | ✅ |
+| ``l_set_exe_icon`` | ✅ | ✅ | ✅ |
 | ``l_opendir`` | ✅ | ✅ | ✅ |
 | ``l_readdir`` | ✅ | ✅ | ✅ |
 | ``l_closedir`` | ✅ | ✅ | ✅ |
@@ -1220,7 +1222,7 @@ Which `l_os.h` functions work on which platform. Generated from code annotations
 | ``l_buf_printf`` | ✅ | ✅ | ✅ |
 | ``l_buf_clear`` | ✅ | ✅ | ✅ |
 | ``l_buf_free`` | ✅ | ✅ | ✅ |
-| **L_Str — fat string (pointer + length) function declarations** | | | |
+| **L_Str â€” fat string (pointer + length) function declarations** | | | |
 | ``l_str`` | ✅ | ✅ | ✅ |
 | ``l_str_from`` | ✅ | ✅ | ✅ |
 | ``l_str_null`` | ✅ | ✅ | ✅ |
@@ -1342,15 +1344,15 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 |----------|--------|-----------|
 | **String functions** | | |
 | `l_wcslen` | ✅ | test_strings.c |
-| `l_strlen` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
-| `l_strcpy` | ✅ | test_strings.c, test.c |
+| `l_strlen` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
+| `l_strcpy` | ✅ | test.c, test_strings.c |
 | `l_strncpy` | ✅ | test_strings.c |
-| `l_strcat` | ✅ | test_strings.c, test.c |
+| `l_strcat` | ✅ | test.c, test_strings.c |
 | `l_strncat` | ✅ | test_strings.c |
 | `l_strchr` | ✅ | test_fs.c, test_strings.c |
 | `l_strrchr` | ✅ | test_strings.c |
-| `l_strstr` | ✅ | test_fs.c, test_strings.c, test.c |
-| `l_strcmp` | ✅ | test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
+| `l_strstr` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_strcmp` | ✅ | test.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
 | `l_strncmp` | ✅ | test_strings.c |
 | `l_strcasecmp` | ✅ | test_strings.c |
 | `l_strncasecmp` | ✅ | test_fs.c, test_strings.c |
@@ -1383,7 +1385,7 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_labs` | ✅ | test_strings.c |
 | `l_llabs` | ✅ | test.c |
 | `l_atol` | ✅ | test_strings.c |
-| `l_atoi` | ✅ | test_strings.c, test.c |
+| `l_atoi` | ✅ | test.c, test_strings.c |
 | `l_strtoul` | ✅ | test_strings.c |
 | `l_strtol` | ✅ | test_strings.c |
 | `l_strtoull` | ✅ | test_strings.c |
@@ -1415,8 +1417,8 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_itoa` | ✅ | test_strings.c |
 | **Memory functions** | | |
 | `l_memmove` | ✅ | test_strings.c |
-| `l_memset` | ✅ | test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
-| `l_memcmp` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_utils.c, test.c |
+| `l_memset` | ✅ | test.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
+| `l_memcmp` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_utils.c |
 | `l_memcpy` | ✅ | test_strings.c, test_utils.c |
 | `l_memchr` | ✅ | test_strings.c |
 | `l_memrchr` | ✅ | test_strings.c |
@@ -1437,30 +1439,30 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_vprintf` | ✅ | test_strings.c |
 | `l_fprintf` | ✅ | test_strings.c |
 | **System functions** | | |
-| `l_exit` | ✅ | test_fs.c, test.c |
-| `l_open` | ✅ | test_fs.c, test.c |
-| `l_close` | ✅ | test_fs.c, test_strings.c, test.c |
-| `l_read` | ✅ | test_fs.c, test_strings.c, test.c |
-| `l_write` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_exit` | ✅ | test.c, test_fs.c |
+| `l_open` | ✅ | test.c, test_fs.c |
+| `l_close` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_read` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_write` | ✅ | test.c, test_fs.c, test_strings.c |
 | `l_read_line` | ✅ | test.c |
 | `l_linebuf_init` | ✅ | test_strings.c |
 | `l_linebuf_read` | ✅ | test_strings.c |
 | `l_time` | ✅ | test_utils.c |
-| `l_puts` | ✅ | test_fs.c, test.c |
+| `l_puts` | ✅ | test.c, test_fs.c |
 | `l_exitif` | ✅ | test_fs.c |
-| `l_getenv` | ✅ | gfx_test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls_live.c, test_tls.c, test_utils.c, test.c |
-| `l_getenv_init` | ✅ | gfx_test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls_live.c, test_tls.c, test_utils.c, test.c |
+| `l_getenv` | ✅ | gfx_test.c, test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_tls_live.c, test_utils.c |
+| `l_getenv_init` | ✅ | gfx_test.c, test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_tls_live.c, test_utils.c |
 | `l_env_start` | ✅ | test_fs.c |
 | `l_env_next` | ✅ | test_fs.c |
 | `l_env_end` | ✅ | test_fs.c |
 | `l_find_executable` | ✅ | test.c |
 | **Option parsing (single-threaded; state in static variables)** | | |
-| `l_getopt` | ✅ | test_utils.c, test.c |
+| `l_getopt` | ✅ | test.c, test_utils.c |
 | `l_getopt_ctx_init` | ✅ | test_utils.c |
 | `l_getopt_ctx` | ✅ | test_utils.c |
 | **Convenience file openers** | | |
-| `l_open_read` | ✅ | test_fs.c, test.c |
-| `l_open_write` | ✅ | test_fs.c, test.c |
+| `l_open_read` | ✅ | test.c, test_fs.c |
+| `l_open_write` | ✅ | test.c, test_fs.c |
 | `l_open_readwrite` | ✅ | test_fs.c |
 | `l_open_append` | ✅ | test_fs.c |
 | `l_open_trunc` | ✅ | test_fs.c |
@@ -1478,10 +1480,10 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_ansi_color` | ✅ | test_term_gfx.c, test_utils.c |
 | `l_ansi_color_rgb` | ✅ | test_term_gfx.c |
 | **File system functions (cross-platform)** | | |
-| `l_unlink` | ✅ | test_fs.c, test.c |
+| `l_unlink` | ✅ | test.c, test_fs.c |
 | `l_rmdir` | ✅ | test_fs.c |
 | `l_rename` | ✅ | test_fs.c |
-| `l_access` | ✅ | test_fs.c, test.c |
+| `l_access` | ✅ | test.c, test_fs.c |
 | `l_chmod` | ✅ | test_fs.c |
 | `l_symlink` | ✅ | test_fs.c |
 | `l_readlink` | ✅ | test_fs.c |
@@ -1493,6 +1495,7 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_file_size` | ✅ | test_fs.c |
 | `l_read_all` | ✅ | test_fs.c |
 | `l_write_all` | ✅ | test_fs.c |
+| ``l_set_exe_icon`` | — | |
 | `l_opendir` | ✅ | test_fs.c |
 | `l_readdir` | ✅ | test_fs.c |
 | `l_closedir` | ✅ | test_fs.c |
@@ -1510,8 +1513,8 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_buf_printf` | ✅ | test_utils.c |
 | `l_buf_clear` | ✅ | test_utils.c |
 | `l_buf_free` | ✅ | test_utils.c |
-| **L_Str — fat string (pointer + length) function declarations** | | |
-| `l_str` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
+| **L_Str â€” fat string (pointer + length) function declarations** | | |
+| `l_str` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
 | `l_str_from` | ✅ | test_utils.c |
 | `l_str_null` | ✅ | test_utils.c |
 | `l_str_eq` | ✅ | test_utils.c |
@@ -1573,7 +1576,7 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_base64_decode` | ✅ | test_utils.c |
 | `l_getcwd` | ✅ | test_fs.c |
 | `l_chdir` | ✅ | test_fs.c |
-| `l_pipe` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_pipe` | ✅ | test.c, test_fs.c, test_strings.c |
 | `l_dup` | ✅ | test.c |
 | `l_dup2` | ✅ | test.c |
 | `l_getpid` | ✅ | test.c |
@@ -1620,7 +1623,7 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | ``l_socket_recvfrom_addr`` | — | |
 | ``l_socket_unix_connect`` | — | |
 
-**Coverage: 244 / 249 functions referenced in tests** (98%)
+**Coverage: 244 / 250 functions referenced in tests** (98%)
 
 <!-- END COVERAGE MATRIX -->
 

--- a/README.md
+++ b/README.md
@@ -759,7 +759,7 @@ Generated from doc-comments. Run `.\gen-docs.ps1` to regenerate.
 | **Arena function declarations** | | |
 | `l_arena_init` | Allocate an arena of `size` bytes via mmap. On failure, base=NULL. | All |
 | `l_arena_alloc` | Bump-allocate n bytes (8-byte aligned). Returns NULL if arena is full. | All |
-| `l_arena_reset` | Reset used to 0. Memory is NOT freed â€” arena can be reused. | All |
+| `l_arena_reset` | Reset used to 0. Memory is NOT freed — arena can be reused. | All |
 | `l_arena_free` | Free the backing memory. Sets base=NULL. | All |
 | **Buffer function declarations** | | |
 | `l_buf_init` | Zero-initialize a buffer. | All |
@@ -767,7 +767,7 @@ Generated from doc-comments. Run `.\gen-docs.ps1` to regenerate.
 | `l_buf_printf` | Formatted append using l_vsnprintf. Returns bytes written or -1. | All |
 | `l_buf_clear` | Set len=0 (keep allocated memory). | All |
 | `l_buf_free` | Free backing memory and zero the struct. | All |
-| **L_Str â€” fat string (pointer + length) function declarations** | | |
+| **L_Str — fat string (pointer + length) function declarations** | | |
 | `l_str` | Wrap a C string (computes strlen). | All |
 | `l_str_from` | Wrap pointer+length. | All |
 | `l_str_null` | Return null string {NULL, 0}. | All |
@@ -1222,7 +1222,7 @@ Which `l_os.h` functions work on which platform. Generated from code annotations
 | ``l_buf_printf`` | ✅ | ✅ | ✅ |
 | ``l_buf_clear`` | ✅ | ✅ | ✅ |
 | ``l_buf_free`` | ✅ | ✅ | ✅ |
-| **L_Str â€” fat string (pointer + length) function declarations** | | | |
+| **L_Str — fat string (pointer + length) function declarations** | | | |
 | ``l_str`` | ✅ | ✅ | ✅ |
 | ``l_str_from`` | ✅ | ✅ | ✅ |
 | ``l_str_null`` | ✅ | ✅ | ✅ |
@@ -1344,15 +1344,15 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 |----------|--------|-----------|
 | **String functions** | | |
 | `l_wcslen` | ✅ | test_strings.c |
-| `l_strlen` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
-| `l_strcpy` | ✅ | test.c, test_strings.c |
+| `l_strlen` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
+| `l_strcpy` | ✅ | test_strings.c, test.c |
 | `l_strncpy` | ✅ | test_strings.c |
-| `l_strcat` | ✅ | test.c, test_strings.c |
+| `l_strcat` | ✅ | test_strings.c, test.c |
 | `l_strncat` | ✅ | test_strings.c |
 | `l_strchr` | ✅ | test_fs.c, test_strings.c |
 | `l_strrchr` | ✅ | test_strings.c |
-| `l_strstr` | ✅ | test.c, test_fs.c, test_strings.c |
-| `l_strcmp` | ✅ | test.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
+| `l_strstr` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_strcmp` | ✅ | test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
 | `l_strncmp` | ✅ | test_strings.c |
 | `l_strcasecmp` | ✅ | test_strings.c |
 | `l_strncasecmp` | ✅ | test_fs.c, test_strings.c |
@@ -1385,7 +1385,7 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_labs` | ✅ | test_strings.c |
 | `l_llabs` | ✅ | test.c |
 | `l_atol` | ✅ | test_strings.c |
-| `l_atoi` | ✅ | test.c, test_strings.c |
+| `l_atoi` | ✅ | test_strings.c, test.c |
 | `l_strtoul` | ✅ | test_strings.c |
 | `l_strtol` | ✅ | test_strings.c |
 | `l_strtoull` | ✅ | test_strings.c |
@@ -1417,8 +1417,8 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_itoa` | ✅ | test_strings.c |
 | **Memory functions** | | |
 | `l_memmove` | ✅ | test_strings.c |
-| `l_memset` | ✅ | test.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
-| `l_memcmp` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_utils.c |
+| `l_memset` | ✅ | test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
+| `l_memcmp` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_utils.c, test.c |
 | `l_memcpy` | ✅ | test_strings.c, test_utils.c |
 | `l_memchr` | ✅ | test_strings.c |
 | `l_memrchr` | ✅ | test_strings.c |
@@ -1439,30 +1439,30 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_vprintf` | ✅ | test_strings.c |
 | `l_fprintf` | ✅ | test_strings.c |
 | **System functions** | | |
-| `l_exit` | ✅ | test.c, test_fs.c |
-| `l_open` | ✅ | test.c, test_fs.c |
-| `l_close` | ✅ | test.c, test_fs.c, test_strings.c |
-| `l_read` | ✅ | test.c, test_fs.c, test_strings.c |
-| `l_write` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_exit` | ✅ | test_fs.c, test.c |
+| `l_open` | ✅ | test_fs.c, test.c |
+| `l_close` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_read` | ✅ | test_fs.c, test_strings.c, test.c |
+| `l_write` | ✅ | test_fs.c, test_strings.c, test.c |
 | `l_read_line` | ✅ | test.c |
 | `l_linebuf_init` | ✅ | test_strings.c |
 | `l_linebuf_read` | ✅ | test_strings.c |
 | `l_time` | ✅ | test_utils.c |
-| `l_puts` | ✅ | test.c, test_fs.c |
+| `l_puts` | ✅ | test_fs.c, test.c |
 | `l_exitif` | ✅ | test_fs.c |
-| `l_getenv` | ✅ | gfx_test.c, test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_tls_live.c, test_utils.c |
-| `l_getenv_init` | ✅ | gfx_test.c, test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls.c, test_tls_live.c, test_utils.c |
+| `l_getenv` | ✅ | gfx_test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls_live.c, test_tls.c, test_utils.c, test.c |
+| `l_getenv_init` | ✅ | gfx_test.c, test_clipboard.c, test_fs.c, test_img.c, test_net.c, test_strings.c, test_svg.c, test_term_gfx.c, test_tls_live.c, test_tls.c, test_utils.c, test.c |
 | `l_env_start` | ✅ | test_fs.c |
 | `l_env_next` | ✅ | test_fs.c |
 | `l_env_end` | ✅ | test_fs.c |
 | `l_find_executable` | ✅ | test.c |
 | **Option parsing (single-threaded; state in static variables)** | | |
-| `l_getopt` | ✅ | test.c, test_utils.c |
+| `l_getopt` | ✅ | test_utils.c, test.c |
 | `l_getopt_ctx_init` | ✅ | test_utils.c |
 | `l_getopt_ctx` | ✅ | test_utils.c |
 | **Convenience file openers** | | |
-| `l_open_read` | ✅ | test.c, test_fs.c |
-| `l_open_write` | ✅ | test.c, test_fs.c |
+| `l_open_read` | ✅ | test_fs.c, test.c |
+| `l_open_write` | ✅ | test_fs.c, test.c |
 | `l_open_readwrite` | ✅ | test_fs.c |
 | `l_open_append` | ✅ | test_fs.c |
 | `l_open_trunc` | ✅ | test_fs.c |
@@ -1480,10 +1480,10 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_ansi_color` | ✅ | test_term_gfx.c, test_utils.c |
 | `l_ansi_color_rgb` | ✅ | test_term_gfx.c |
 | **File system functions (cross-platform)** | | |
-| `l_unlink` | ✅ | test.c, test_fs.c |
+| `l_unlink` | ✅ | test_fs.c, test.c |
 | `l_rmdir` | ✅ | test_fs.c |
 | `l_rename` | ✅ | test_fs.c |
-| `l_access` | ✅ | test.c, test_fs.c |
+| `l_access` | ✅ | test_fs.c, test.c |
 | `l_chmod` | ✅ | test_fs.c |
 | `l_symlink` | ✅ | test_fs.c |
 | `l_readlink` | ✅ | test_fs.c |
@@ -1513,8 +1513,8 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_buf_printf` | ✅ | test_utils.c |
 | `l_buf_clear` | ✅ | test_utils.c |
 | `l_buf_free` | ✅ | test_utils.c |
-| **L_Str â€” fat string (pointer + length) function declarations** | | |
-| `l_str` | ✅ | test.c, test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c |
+| **L_Str — fat string (pointer + length) function declarations** | | |
+| `l_str` | ✅ | test_clipboard.c, test_fs.c, test_net.c, test_strings.c, test_term_gfx.c, test_utils.c, test.c |
 | `l_str_from` | ✅ | test_utils.c |
 | `l_str_null` | ✅ | test_utils.c |
 | `l_str_eq` | ✅ | test_utils.c |
@@ -1576,7 +1576,7 @@ Which `l_os.h` functions are referenced in the test suite. Generated — run `.\
 | `l_base64_decode` | ✅ | test_utils.c |
 | `l_getcwd` | ✅ | test_fs.c |
 | `l_chdir` | ✅ | test_fs.c |
-| `l_pipe` | ✅ | test.c, test_fs.c, test_strings.c |
+| `l_pipe` | ✅ | test_fs.c, test_strings.c, test.c |
 | `l_dup` | ✅ | test.c |
 | `l_dup2` | ✅ | test.c |
 | `l_getpid` | ✅ | test.c |

--- a/examples/set_icon.c
+++ b/examples/set_icon.c
@@ -1,0 +1,86 @@
+// Demonstrates l_set_exe_icon: builds a minimal 16x16 .ico file on disk and
+// applies it to a target .exe (Windows). On non-Windows platforms
+// l_set_exe_icon is a no-op and the program exits successfully.
+//
+// Usage:
+//   set_icon                   -- builds test_icon.ico in the cwd only
+//   set_icon <target.exe>      -- also patches the target executable's icon
+//
+// Note: the target exe must not be currently running (Windows locks it).
+// Try copying a binary first, e.g.
+//   copy bin\hello.exe bin\hello_copy.exe
+//   bin\set_icon bin\hello_copy.exe
+
+#define L_MAINFILE
+#include "l_os.h"
+
+// Build a minimal valid 1-bit 16x16 .ico (198 bytes, all pixels opaque white).
+static size_t build_test_ico(unsigned char *p) {
+    unsigned char *start = p;
+
+    // ICONDIR: reserved=0, type=1 (icon), count=1
+    *p++ = 0; *p++ = 0; *p++ = 1; *p++ = 0; *p++ = 1; *p++ = 0;
+
+    // ICONDIRENTRY (16 bytes)
+    *p++ = 16; *p++ = 16;                     // 16x16
+    *p++ = 2;  *p++ = 0;                      // 2 colors, reserved
+    *p++ = 1;  *p++ = 0;                      // planes = 1
+    *p++ = 1;  *p++ = 0;                      // bitcount = 1
+    *p++ = 176;*p++ = 0; *p++ = 0; *p++ = 0;  // bytesInRes = 176
+    *p++ = 22; *p++ = 0; *p++ = 0; *p++ = 0;  // image offset = 22
+
+    // BITMAPINFOHEADER (40 bytes): 16 wide, 32 tall (xor+and), 1bpp
+    static const unsigned char bih[40] = {
+        40,0,0,0,  16,0,0,0,  32,0,0,0,
+         1,0,       1,0,       0,0,0,0,
+         0,0,0,0,   0,0,0,0,   0,0,0,0,
+         2,0,0,0,   0,0,0,0,
+    };
+    for (int i = 0; i < 40; i++) *p++ = bih[i];
+
+    // Palette: index 0 = black, index 1 = white (BGRA)
+    *p++ = 0x00; *p++ = 0x00; *p++ = 0x00; *p++ = 0x00;
+    *p++ = 0xFF; *p++ = 0xFF; *p++ = 0xFF; *p++ = 0x00;
+
+    // XOR mask: 16 rows, DWORD-aligned (2 data bytes + 2 padding).
+    // All pixels set to color index 1 (white).
+    for (int r = 0; r < 16; r++) {
+        *p++ = 0xFF; *p++ = 0xFF; *p++ = 0x00; *p++ = 0x00;
+    }
+
+    // AND mask: 16 rows, DWORD-aligned, all zero = fully opaque.
+    for (int i = 0; i < 64; i++) *p++ = 0x00;
+
+    return (size_t)(p - start);
+}
+
+int main(int argc, char *argv[]) {
+    unsigned char ico[256];
+    size_t n = build_test_ico(ico);
+
+    const char *ico_path = "test_icon.ico";
+    L_FD fd = l_open_trunc(ico_path);
+    if (fd < 0) {
+        puts("error: could not create test_icon.ico\n");
+        return 1;
+    }
+    if (l_write_all(fd, ico, n) != (ptrdiff_t)n) {
+        l_close(fd);
+        puts("error: could not write test_icon.ico\n");
+        return 1;
+    }
+    l_close(fd);
+    puts("wrote test_icon.ico\n");
+
+    if (argc < 2) {
+        puts("no target .exe given; skipping icon patch\n");
+        return 0;
+    }
+
+    if (l_set_exe_icon(argv[1], ico_path) != 0) {
+        puts("error: l_set_exe_icon failed\n");
+        return 1;
+    }
+    puts("icon updated\n");
+    return 0;
+}

--- a/l_os.h
+++ b/l_os.h
@@ -831,6 +831,11 @@ static inline long long l_file_size(const char *path);
 static inline ptrdiff_t l_read_all(L_FD fd, void *buf, size_t count);
 /// Writes exactly count bytes, retrying on short writes. Returns total bytes written, or negative on error.
 static inline ptrdiff_t l_write_all(L_FD fd, const void *buf, size_t count);
+/// Sets the icon of an executable file from an .ico file on disk.
+/// On Windows, patches the target .exe's RT_ICON / RT_GROUP_ICON resources.
+/// On non-Windows platforms this is a no-op (executables don't embed icons).
+/// Returns 0 on success, -1 on error. The target must not be currently running.
+static inline int l_set_exe_icon(const char *exe_path, const char *ico_path);
 /// Opens a directory for reading. Returns 0 on success, -1 on error.
 static inline int l_opendir(const char *path, L_Dir *dir);
 /// Reads the next directory entry. Returns pointer to L_DirEntry or NULL when done.
@@ -9516,6 +9521,89 @@ static inline int l_path_isdir(const char *path) {
     L_Stat st;
     if (l_stat(path, &st) != 0) return 0;
     return L_S_ISDIR(st.st_mode) ? 1 : 0;
+}
+
+// --- l_set_exe_icon: patch the icon of an executable ---
+
+static inline int l_set_exe_icon(const char *exe_path, const char *ico_path) {
+#ifdef _WIN32
+    if (!exe_path || !ico_path) return -1;
+
+    long long fsize = l_file_size(ico_path);
+    // Minimum valid ICO: 6-byte header + one 16-byte entry + some image data.
+    if (fsize < 22 || fsize > (1LL << 24)) return -1;
+
+    L_FD fd = l_open_read(ico_path);
+    if (fd < 0) return -1;
+
+    L_Arena arena = l_arena_init((size_t)fsize + 4096);
+    if (!arena.base) { l_close(fd); return -1; }
+
+    unsigned char *ico = (unsigned char *)l_arena_alloc(&arena, (size_t)fsize);
+    if (!ico) { l_arena_free(&arena); l_close(fd); return -1; }
+    ptrdiff_t got = l_read_all(fd, ico, (size_t)fsize);
+    l_close(fd);
+    if (got != (ptrdiff_t)fsize) { l_arena_free(&arena); return -1; }
+
+    // Parse ICONDIR
+    unsigned short reserved = (unsigned short)(ico[0] | (ico[1] << 8));
+    unsigned short type     = (unsigned short)(ico[2] | (ico[3] << 8));
+    unsigned short count    = (unsigned short)(ico[4] | (ico[5] << 8));
+    if (reserved != 0 || type != 1 || count == 0) { l_arena_free(&arena); return -1; }
+    if ((long long)(6 + (long long)count * 16) > fsize) { l_arena_free(&arena); return -1; }
+
+    // Build RT_GROUP_ICON: 6-byte header + 14*count entries (replacing the
+    // 4-byte image offset in each ICONDIRENTRY with a 2-byte resource ID).
+    size_t group_size = (size_t)(6 + 14 * (size_t)count);
+    unsigned char *group = (unsigned char *)l_arena_alloc(&arena, group_size);
+    if (!group) { l_arena_free(&arena); return -1; }
+    l_memcpy(group, ico, 6);
+    for (unsigned short i = 0; i < count; i++) {
+        unsigned char *src = ico + 6 + i * 16;
+        unsigned char *dst = group + 6 + i * 14;
+        l_memcpy(dst, src, 12);
+        unsigned short id = (unsigned short)(i + 1);
+        dst[12] = (unsigned char)(id & 0xFF);
+        dst[13] = (unsigned char)((id >> 8) & 0xFF);
+    }
+
+    wchar_t wexe[L_PATH_MAX];
+    int nexe = MultiByteToWideChar(CP_UTF8, 0, exe_path, -1, wexe, L_PATH_MAX);
+    if (nexe <= 0) { l_arena_free(&arena); return -1; }
+
+    HANDLE h = BeginUpdateResourceW(wexe, FALSE);
+    if (!h) { l_arena_free(&arena); return -1; }
+
+    int ok = 1;
+    WORD lang = MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL);
+    for (unsigned short i = 0; i < count && ok; i++) {
+        unsigned char *src = ico + 6 + i * 16;
+        DWORD img_size = (DWORD)src[8]
+                       | ((DWORD)src[9]  << 8)
+                       | ((DWORD)src[10] << 16)
+                       | ((DWORD)src[11] << 24);
+        DWORD img_off  = (DWORD)src[12]
+                       | ((DWORD)src[13] << 8)
+                       | ((DWORD)src[14] << 16)
+                       | ((DWORD)src[15] << 24);
+        if ((long long)img_off + (long long)img_size > fsize) { ok = 0; break; }
+        if (!UpdateResourceW(h, (LPWSTR)RT_ICON, MAKEINTRESOURCEW(i + 1),
+                             lang, ico + img_off, img_size)) ok = 0;
+    }
+
+    if (ok) {
+        if (!UpdateResourceW(h, (LPWSTR)RT_GROUP_ICON, MAKEINTRESOURCEW(1),
+                             lang, group, (DWORD)group_size)) ok = 0;
+    }
+
+    if (!EndUpdateResourceW(h, ok ? FALSE : TRUE)) ok = 0;
+
+    l_arena_free(&arena);
+    return ok ? 0 : -1;
+#else
+    (void)exe_path; (void)ico_path;
+    return 0;
+#endif
 }
 
 #endif // L_OSH


### PR DESCRIPTION
Exposes a small helper for setting the icon of a built executable, which is useful when packaging tools built against this runtime (previously there was no way to brand the .exe without an external tool like rcedit).

## Approach

- `l_set_exe_icon(exe_path, ico_path)` in `l_os.h` is cross-platform by design. On Windows it reads the .ico, parses the ICONDIR / ICONDIRENTRY records, and rewrites the exe's `RT_ICON` (IDs 1..N) and `RT_GROUP_ICON` (ID 1) resources via `BeginUpdateResourceW` / `UpdateResourceW` / `EndUpdateResourceW`.
- On non-Windows platforms it is a deliberate no-op that returns 0, since ELF / Mach-O binaries do not embed icons. This keeps calling code portable without `#ifdef`s.
- Uses an `L_Arena` for the ICO buffer + synthesized GROUP_ICON, so there is no heap dependency and cleanup is a single `l_arena_free`.

## Example

`examples/set_icon.c` builds a minimal 1-bit 16x16 .ico at runtime (no external asset needed) and applies it to a target executable passed as `argv[1]`. Smoke-tested by copying `bin\hello.exe` and patching the copy.

## Notes for reviewers

- The target .exe must not be currently running when patched (Windows locks the file) - this is documented in the doc comment.
- ICO bounds are validated (header, per-entry image offset+size within file, sane overall size cap of 16MB) before any resource writes.
- Full CI passes on all 7 targets (Win clang, Linux gcc/clang, ARM gcc/clang, AArch64 gcc/clang). The one pre-existing `test_clipboard` flaky assertion on Windows is unchanged.